### PR TITLE
richer identification mechanism

### DIFF
--- a/src/autonormal/ident.cljc
+++ b/src/autonormal/ident.cljc
@@ -1,0 +1,111 @@
+(ns autonormal.ident
+  "Tools for identifying entity maps & creating ident functions.
+
+  An 'ident function' is a function that takes a map and returns a tuple
+  [:key val] that uniquely identifies the entity the map describes."
+  (:refer-clojure :exclude [ident?]))
+
+
+(defn ident
+  "Takes a key and value and returns an ident."
+  [k v]
+  [k v])
+
+
+(defn ident?
+  [x]
+  (and (vector? x)
+       (= 2 (count x))
+       (keyword? (first x))))
+
+
+(defn by*
+  "Takes a collection of functions. Returns an ident function that calls the
+  first function on a map, then the second, and so on until one of the functions
+  returns a non-nil value, which should be an ident.
+
+  Returns nil if all functions return nil."
+  [fns]
+  (fn ident-by
+    [entity]
+    (some #(% entity) fns)))
+
+
+(defn by
+  "Takes a number of functions. Returns an ident function that calls the
+  first function on a map, then the second, and so on until one of the functions
+  returns a non-nil value, which should be an ident.
+
+  Returns nil if all functions return nil."
+  [& fns]
+  (by* fns))
+
+
+(comment
+  (defn person
+    [e]
+    (when-some [pid (:person/id e)]
+      [:person/id pid]))
+
+  (defn item
+    [e]
+    (when-some [id (:item/id e)]
+      [:item/id id]))
+
+  (def identify (by person item))
+
+  (identify {:person/id 1})
+
+  (identify {:item/id 1})
+
+  (identify {:food/id 1})
+
+  ;; composes
+  (def identify2 (by identify (fn static-ident [_e] [:foo 1])))
+
+  (identify2 {:person/id 1})
+
+  (identify2 {:item/id 1})
+
+  (identify2 {:asdf 1}))
+
+
+(defn identify-by-key
+  "Takes an entity and a key, and returns an ident using key and value in entity
+  if found. Otherwise returns nil."
+  [entity key]
+  (let [v (get entity key ::not-found)]
+    (when (not= v ::not-found)
+      (ident key v))))
+
+
+(defn by-keys*
+  "Takes a collection of keys. Returns an ident function that looks for the
+  first key in a map, then the second, and so on until it finds a matching
+  key, then returns an ident using that key and the value found.
+
+  Returns nil if no keys are found."
+  [keys]
+  (fn identify-by-keys
+    [entity]
+    (some #(identify-by-key entity %) keys)))
+
+
+(defn by-keys
+  "Takes a number of keys. Returns an ident function that looks for the
+  first key in a map, then the second, and so on until it finds a matching
+  key, then returns an ident using that key and the value found.
+
+  Returns nil if no keys are found."
+  [& keys]
+  (by-keys* keys))
+
+
+(comment
+  (def identify-keys (by-keys :person/id :item/id))
+
+  (identify-keys {:person/id 1})
+
+  (identify-keys {:item/id 1})
+
+  (identify-keys {:food/id 1}))

--- a/src/autonormal/ident.cljc
+++ b/src/autonormal/ident.cljc
@@ -37,8 +37,12 @@
   returns a non-nil value, which should be an ident.
 
   Returns nil if all functions return nil."
-  [& fns]
-  (by* fns))
+  ([f]
+   (fn ident-by-1
+     [entity]
+     (f entity)))
+  ([f & fns]
+   (by* (cons f fns))))
 
 
 (comment
@@ -97,8 +101,10 @@
   key, then returns an ident using that key and the value found.
 
   Returns nil if no keys are found."
-  [& keys]
-  (by-keys* keys))
+  ([key]
+   #(identify-by-key % key))
+  ([key & keys]
+   (by-keys* (cons key keys))))
 
 
 (comment

--- a/test/autonormal/core_test.cljc
+++ b/test/autonormal/core_test.cljc
@@ -80,11 +80,37 @@
 (t/deftest custom-schema
   (t/is (= {:color {"red" {:color "red" :hex "#ff0000"}}}
            (a/db [{:color "red" :hex "#ff0000"}]
-                 (ident/by-keys :color))))
+                 (ident/by-keys :color)))
+        "ident/by-keys")
   (t/is (= {:color {"red" {:color "red" :hex "#ff0000"}}}
            (a/db [^{:db/ident :color}
                   {:color "red" :hex "#ff0000"}]))
-        "local schema"))
+        "local schema")
+  (t/testing "complex schema"
+    (let [db (a/db [{:type "person"
+                     :id "1234"
+                     :purchases [{:type "item"
+                                  :id "1234"}]}
+                    {:type "item"
+                     :id "5678"}
+                    {:type "foo"}
+                    {:id "bar"}]
+                   (fn [entity]
+                     (let [{:keys [type id]} entity]
+                       (when (and (some? type) (some? id))
+                         [(keyword type "id") id]))))]
+      (t/is (= {:person/id
+                {"1234" {:type "person", :id "1234", :purchases [[:item/id "1234"]]}},
+                :item/id
+                {"1234" {:type "item", :id "1234"}, "5678" {:type "item", :id "5678"}},
+                :type "foo",
+                :id "bar"}
+               db)
+            "correctly identifies entities")
+      (t/is (= {[:person/id "1234"]
+                {:type "person", :id "1234", :purchases [{:type "item", :id "1234"}]}}
+               (a/pull db [{[:person/id "1234"] [:type :id {:purchases [:type :id]}]}]))
+            "pull"))))
 
 
 (t/deftest add

--- a/test/autonormal/core_test.cljc
+++ b/test/autonormal/core_test.cljc
@@ -1,6 +1,7 @@
 (ns autonormal.core-test
   (:require
    [autonormal.core :as a]
+   [autonormal.ident :as ident]
    [clojure.test :as t]))
 
 
@@ -79,7 +80,7 @@
 (t/deftest custom-schema
   (t/is (= {:color {"red" {:color "red" :hex "#ff0000"}}}
            (a/db [{:color "red" :hex "#ff0000"}]
-                 #{:color})))
+                 (ident/by-keys :color))))
   (t/is (= {:color {"red" {:color "red" :hex "#ff0000"}}}
            (a/db [^{:db/ident :color}
                   {:color "red" :hex "#ff0000"}]))


### PR DESCRIPTION
This PR changes the way that entity identification works.

Currently, we try to figure out how to identify a map by checking each key without context. This precludes more complex logic, such as preferring one ID over another or using a composite of multiple keys to produce an ident.

Now, when you create a new db value, you may provide it a function that takes the entire map as a value and returns either an ident (a tuple `[key val]` that uniquely identifies the entity in your system) or `nil`.

`autonormal.ident` is a new namespace that has some tools for constructing and composing these functions, such as:

```clojure
(require '[autonormal.core :as a]
         '[autonormal.core :as ident])

(a/db [{:foo/id 1} {:bar/id 1}] (ident/by-keys :foo/id :bar/id))
```

which is nearly equivalent to passing a a set `{:foo/id :bar/id}` as the second argument to `db` today, except that it will preserve order of the keys when checking the entity for it.