### PR TITLE
Ensure that that `name` isn't run on map keys that are not keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /target/
 /pom.xml.asc
 /pom.xml
+.idea
+*.iml

--- a/src/autonormal/core.cljc
+++ b/src/autonormal/core.cljc
@@ -28,7 +28,9 @@
    (fn ident-by-id [entity]
      (loop [kvs entity]
        (when-some [[k v] (first kvs)]
-         (if (= "id" (name k))
+         (if (and
+               (keyword? k)
+               (= "id" (name k)))
            (ident/ident k v)
            (recur (rest kvs))))))))
 

--- a/test/autonormal/core_test.cljc
+++ b/test/autonormal/core_test.cljc
@@ -9,13 +9,6 @@
   (t/is (= {:person/id {0 {:person/id 0}}}
            (a/db [{:person/id 0}]))
         "a single entity")
-  (t/is (= (a/add {} {:id 10
-                      :some-data {1 "hello"
-                                  3 "world"}})
-           {:id {10 {:id 10
-                     :some-data {1 "hello"
-                                 3 "world"}}}})
-    "Map with numbers as keys")
   (t/is (= {:person/id {0 {:person/id 0
                            :person/name "asdf"}
                         1 {:person/id 1
@@ -36,6 +29,13 @@
                             {:person/id 1
                              :person/name "jkl"}]}]))
         "nested under a key")
+  (t/is (= {:person/id {0 {:person/id 0
+                           :some-data {1 "hello"
+                                       3 "world"}}}}
+           (a/db [{:person/id 0
+                   :some-data {1 "hello"
+                               3 "world"}}]))
+    "Map with numbers as keys")
   (t/is (= {:person/id
             {123
              {:person/id 123,

--- a/test/autonormal/core_test.cljc
+++ b/test/autonormal/core_test.cljc
@@ -14,7 +14,8 @@
                                   3 "world"}})
            {:id {10 {:id 10
                      :some-data {1 "hello"
-                                 3 "world"}}}}))
+                                 3 "world"}}}})
+    "Map with numbers as keys")
   (t/is (= {:person/id {0 {:person/id 0
                            :person/name "asdf"}
                         1 {:person/id 1

--- a/test/autonormal/core_test.cljc
+++ b/test/autonormal/core_test.cljc
@@ -9,6 +9,12 @@
   (t/is (= {:person/id {0 {:person/id 0}}}
            (a/db [{:person/id 0}]))
         "a single entity")
+  (t/is (= (a/add {} {:id 10
+                      :some-data {1 "hello"
+                                  3 "world"}})
+           {:id {10 {:id 10
+                     :some-data {1 "hello"
+                                 3 "world"}}}}))
   (t/is (= {:person/id {0 {:person/id 0
                            :person/name "asdf"}
                         1 {:person/id 1
@@ -27,7 +33,7 @@
            (a/db [{:people [{:person/id 0
                              :person/name "asdf"}
                             {:person/id 1
-                             :person/name "jkl"}] } ]))
+                             :person/name "jkl"}]}]))
         "nested under a key")
   (t/is (= {:person/id
             {123
@@ -142,9 +148,9 @@
                                   :best-friend {:person/id 1
                                                 :person/name "Uma"}}})))
   #_(t/is (= {:db {:person/id {0 {:person/id 0 :person/name "Gill"}
-                             1 {:person/id 1}}}
-            :entities #{{:person/id 0 :person/name "Gill"}
-                        {:person/id 1}}}
+                               1 {:person/id 1}}}
+              :entities #{{:person/id 0 :person/name "Gill"}
+                          {:person/id 1}}}
            (a/add-report
             {}
             {:person/id 0}
@@ -414,7 +420,7 @@
                      [{:entry/id "qwerty"}]}
                     {:entry/id "jkl"
                      :entry/folders
-                     [{:entry/id "uiop"}]}]}]} }
+                     [{:entry/id "uiop"}]}]}]}}
           db (a/db [data])]
       (t/is (= data
                (a/pull db '[{:entries [:entry/id


### PR DESCRIPTION
When Autonormal tries to create a `default-ident`, it will choke on maps that contain non-keyword keys, such as errors returned from Pathom. 